### PR TITLE
fix: pemd tags - natural category order

### DIFF
--- a/src/routes/(app)/app/admin/categories/+page.server.ts
+++ b/src/routes/(app)/app/admin/categories/+page.server.ts
@@ -5,86 +5,98 @@ import type { Actions, PageServerLoad } from './$types';
 import { fail } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async () => {
-    const categories = await db.select({
-        id: categorieV2.id,
-        categorie: categorieV2.categoriev2,
-        groupeId: categorieV2.groupeId,
-        groupeName: groupe.groupe
-    })
-    .from(categorieV2)
-    .leftJoin(groupe, eq(categorieV2.groupeId, groupe.id))
-    .all();
+	const categories = await db
+		.select({
+			id: categorieV2.id,
+			categorie: categorieV2.categoriev2,
+			groupeId: categorieV2.groupeId,
+			groupeName: groupe.groupe
+		})
+		.from(categorieV2)
+		.leftJoin(groupe, eq(categorieV2.groupeId, groupe.id))
+		.all();
 
-    const groupes = await db.select().from(groupe).all();
+	const groupes = await db.select().from(groupe).all();
 
-    return {
-        categories,
-        groupes
-    };
+	const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+	categories.sort((a, b) => {
+		const g = collator.compare(a.groupeName || '', b.groupeName || '');
+		if (g !== 0) return g;
+		return collator.compare(a.categorie || '', b.categorie || '');
+	});
+
+	groupes.sort((a, b) => collator.compare(a.groupe || '', b.groupe || ''));
+
+	return {
+		categories,
+		groupes
+	};
 };
 
 export const actions: Actions = {
-    create: async ({ request }) => {
-        const formData = await request.formData();
-        const categorieName = formData.get('categorie') as string;
-        const groupeId = Number(formData.get('groupeId'));
-        
-        if (!categorieName || !groupeId) {
-            return fail(400, { message: 'Le nom de la catégorie et le groupe sont requis' });
-        }
+	create: async ({ request }) => {
+		const formData = await request.formData();
+		const categorieName = formData.get('categorie') as string;
+		const groupeId = Number(formData.get('groupeId'));
 
-        try {
-            await db.insert(categorieV2).values({
-                categoriev2: categorieName,
-                groupeId: groupeId
-            });
+		if (!categorieName || !groupeId) {
+			return fail(400, { message: 'Le nom de la catégorie et le groupe sont requis' });
+		}
 
-            return { success: true };
-        } catch (e: any) {
-            console.error('Error creating category:', e);
-            return fail(500, { message: 'Erreur lors de la création' });
-        }
-    },
+		try {
+			await db.insert(categorieV2).values({
+				categoriev2: categorieName,
+				groupeId: groupeId
+			});
 
-    update: async ({ request }) => {
-        const formData = await request.formData();
-        const id = Number(formData.get('id'));
-        const categorieName = formData.get('categorie') as string;
-        const groupeId = Number(formData.get('groupeId'));
+			return { success: true };
+		} catch (e: any) {
+			console.error('Error creating category:', e);
+			return fail(500, { message: 'Erreur lors de la création' });
+		}
+	},
 
-        if (!id || !categorieName || !groupeId) {
-            return fail(400, { message: 'ID, nom de la catégorie et groupe requis' });
-        }
+	update: async ({ request }) => {
+		const formData = await request.formData();
+		const id = Number(formData.get('id'));
+		const categorieName = formData.get('categorie') as string;
+		const groupeId = Number(formData.get('groupeId'));
 
-        try {
-            await db.update(categorieV2)
-                .set({
-                    categoriev2: categorieName,
-                    groupeId: groupeId
-                })
-                .where(eq(categorieV2.id, id));
+		if (!id || !categorieName || !groupeId) {
+			return fail(400, { message: 'ID, nom de la catégorie et groupe requis' });
+		}
 
-            return { success: true };
-        } catch (e: any) {
-            console.error('Error updating category:', e);
-            return fail(500, { message: 'Erreur lors de la mise à jour' });
-        }
-    },
+		try {
+			await db
+				.update(categorieV2)
+				.set({
+					categoriev2: categorieName,
+					groupeId: groupeId
+				})
+				.where(eq(categorieV2.id, id));
 
-    delete: async ({ request }) => {
-        const formData = await request.formData();
-        const id = Number(formData.get('id'));
+			return { success: true };
+		} catch (e: any) {
+			console.error('Error updating category:', e);
+			return fail(500, { message: 'Erreur lors de la mise à jour' });
+		}
+	},
 
-        if (!id) {
-            return fail(400, { message: 'ID requis' });
-        }
+	delete: async ({ request }) => {
+		const formData = await request.formData();
+		const id = Number(formData.get('id'));
 
-        try {
-            await db.delete(categorieV2).where(eq(categorieV2.id, id));
-            return { success: true };
-        } catch (e: any) {
-            console.error('Error deleting category:', e);
-            return fail(500, { message: 'Erreur lors de la suppression' });
-        }
-    }
+		if (!id) {
+			return fail(400, { message: 'ID requis' });
+		}
+
+		try {
+			await db.delete(categorieV2).where(eq(categorieV2.id, id));
+			return { success: true };
+		} catch (e: any) {
+			console.error('Error deleting category:', e);
+			return fail(500, { message: 'Erreur lors de la suppression' });
+		}
+	}
 };

--- a/src/routes/(app)/app/admin/macro-categories/+page.server.ts
+++ b/src/routes/(app)/app/admin/macro-categories/+page.server.ts
@@ -5,70 +5,75 @@ import type { Actions, PageServerLoad } from './$types';
 import { fail } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async () => {
-    const groupes = await db.select().from(groupe).all();
-    return {
-        groupes
-    };
+	const groupes = await db.select().from(groupe).all();
+
+	const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+	groupes.sort((a, b) => collator.compare(a.groupe || '', b.groupe || ''));
+
+	return {
+		groupes
+	};
 };
 
 export const actions: Actions = {
-    create: async ({ request }) => {
-        const formData = await request.formData();
-        const groupeName = formData.get('groupe') as string;
-        
-        if (!groupeName) {
-            return fail(400, { message: 'Le nom du groupe est requis' });
-        }
+	create: async ({ request }) => {
+		const formData = await request.formData();
+		const groupeName = formData.get('groupe') as string;
 
-        try {
-            await db.insert(groupe).values({
-                groupe: groupeName,
-            });
+		if (!groupeName) {
+			return fail(400, { message: 'Le nom du groupe est requis' });
+		}
 
-            return { success: true };
-        } catch (e: any) {
-            console.error('Error creating groupe:', e);
-            return fail(500, { message: 'Erreur lors de la création' });
-        }
-    },
+		try {
+			await db.insert(groupe).values({
+				groupe: groupeName
+			});
 
-    update: async ({ request }) => {
-        const formData = await request.formData();
-        const id = Number(formData.get('id'));
-        const groupeName = formData.get('groupe') as string;
+			return { success: true };
+		} catch (e: any) {
+			console.error('Error creating groupe:', e);
+			return fail(500, { message: 'Erreur lors de la création' });
+		}
+	},
 
-        if (!id || !groupeName) {
-            return fail(400, { message: 'ID et nom du groupe requis' });
-        }
+	update: async ({ request }) => {
+		const formData = await request.formData();
+		const id = Number(formData.get('id'));
+		const groupeName = formData.get('groupe') as string;
 
-        try {
-            await db.update(groupe)
-                .set({
-                    groupe: groupeName,
-                })
-                .where(eq(groupe.id, id));
+		if (!id || !groupeName) {
+			return fail(400, { message: 'ID et nom du groupe requis' });
+		}
 
-            return { success: true };
-        } catch (e: any) {
-            console.error('Error updating groupe:', e);
-            return fail(500, { message: 'Erreur lors de la mise à jour' });
-        }
-    },
+		try {
+			await db
+				.update(groupe)
+				.set({
+					groupe: groupeName
+				})
+				.where(eq(groupe.id, id));
 
-    delete: async ({ request }) => {
-        const formData = await request.formData();
-        const id = Number(formData.get('id'));
+			return { success: true };
+		} catch (e: any) {
+			console.error('Error updating groupe:', e);
+			return fail(500, { message: 'Erreur lors de la mise à jour' });
+		}
+	},
 
-        if (!id) {
-            return fail(400, { message: 'ID requis' });
-        }
+	delete: async ({ request }) => {
+		const formData = await request.formData();
+		const id = Number(formData.get('id'));
 
-        try {
-            await db.delete(groupe).where(eq(groupe.id, id));
-            return { success: true };
-        } catch (e: any) {
-            console.error('Error deleting groupe:', e);
-            return fail(500, { message: 'Erreur lors de la suppression' });
-        }
-    }
+		if (!id) {
+			return fail(400, { message: 'ID requis' });
+		}
+
+		try {
+			await db.delete(groupe).where(eq(groupe.id, id));
+			return { success: true };
+		} catch (e: any) {
+			console.error('Error deleting groupe:', e);
+			return fail(500, { message: 'Erreur lors de la suppression' });
+		}
+	}
 };

--- a/src/routes/(app)/app/admin/objets/+page.server.ts
+++ b/src/routes/(app)/app/admin/objets/+page.server.ts
@@ -5,86 +5,98 @@ import type { Actions, PageServerLoad } from './$types';
 import { fail } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async () => {
-    const objetsList = await db.select({
-        id: objets.id,
-        objet: objets.objet,
-        categorieId: objets.categorieId,
-        categorieName: categorieV2.categoriev2
-    })
-    .from(objets)
-    .leftJoin(categorieV2, eq(objets.categorieId, categorieV2.id))
-    .all();
+	const objetsList = await db
+		.select({
+			id: objets.id,
+			objet: objets.objet,
+			categorieId: objets.categorieId,
+			categorieName: categorieV2.categoriev2
+		})
+		.from(objets)
+		.leftJoin(categorieV2, eq(objets.categorieId, categorieV2.id))
+		.all();
 
-    const categories = await db.select().from(categorieV2).all();
+	const categories = await db.select().from(categorieV2).all();
 
-    return {
-        objets: objetsList,
-        categories
-    };
+	const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+	objetsList.sort((a, b) => {
+		const c = collator.compare(a.categorieName || '', b.categorieName || '');
+		if (c !== 0) return c;
+		return collator.compare(a.objet || '', b.objet || '');
+	});
+
+	categories.sort((a, b) => collator.compare(a.categoriev2 || '', b.categoriev2 || ''));
+
+	return {
+		objets: objetsList,
+		categories
+	};
 };
 
 export const actions: Actions = {
-    create: async ({ request }) => {
-        const formData = await request.formData();
-        const objetName = formData.get('objet') as string;
-        const categorieId = Number(formData.get('categorieId'));
-        
-        if (!objetName || !categorieId) {
-            return fail(400, { message: 'Le nom de l\'objet et la catégorie sont requis' });
-        }
+	create: async ({ request }) => {
+		const formData = await request.formData();
+		const objetName = formData.get('objet') as string;
+		const categorieId = Number(formData.get('categorieId'));
 
-        try {
-            await db.insert(objets).values({
-                objet: objetName,
-                categorieId: categorieId
-            });
+		if (!objetName || !categorieId) {
+			return fail(400, { message: "Le nom de l'objet et la catégorie sont requis" });
+		}
 
-            return { success: true };
-        } catch (e: any) {
-            console.error('Error creating objet:', e);
-            return fail(500, { message: 'Erreur lors de la création' });
-        }
-    },
+		try {
+			await db.insert(objets).values({
+				objet: objetName,
+				categorieId: categorieId
+			});
 
-    update: async ({ request }) => {
-        const formData = await request.formData();
-        const id = Number(formData.get('id'));
-        const objetName = formData.get('objet') as string;
-        const categorieId = Number(formData.get('categorieId'));
+			return { success: true };
+		} catch (e: any) {
+			console.error('Error creating objet:', e);
+			return fail(500, { message: 'Erreur lors de la création' });
+		}
+	},
 
-        if (!id || !objetName || !categorieId) {
-            return fail(400, { message: 'ID, nom de l\'objet et catégorie requis' });
-        }
+	update: async ({ request }) => {
+		const formData = await request.formData();
+		const id = Number(formData.get('id'));
+		const objetName = formData.get('objet') as string;
+		const categorieId = Number(formData.get('categorieId'));
 
-        try {
-            await db.update(objets)
-                .set({
-                    objet: objetName,
-                    categorieId: categorieId
-                })
-                .where(eq(objets.id, id));
+		if (!id || !objetName || !categorieId) {
+			return fail(400, { message: "ID, nom de l'objet et catégorie requis" });
+		}
 
-            return { success: true };
-        } catch (e: any) {
-            console.error('Error updating objet:', e);
-            return fail(500, { message: 'Erreur lors de la mise à jour' });
-        }
-    },
+		try {
+			await db
+				.update(objets)
+				.set({
+					objet: objetName,
+					categorieId: categorieId
+				})
+				.where(eq(objets.id, id));
 
-    delete: async ({ request }) => {
-        const formData = await request.formData();
-        const id = Number(formData.get('id'));
+			return { success: true };
+		} catch (e: any) {
+			console.error('Error updating objet:', e);
+			return fail(500, { message: 'Erreur lors de la mise à jour' });
+		}
+	},
 
-        if (!id) {
-            return fail(400, { message: 'ID requis' });
-        }
+	delete: async ({ request }) => {
+		const formData = await request.formData();
+		const id = Number(formData.get('id'));
 
-        try {
-            await db.delete(objets).where(eq(objets.id, id));
-            return { success: true };
-        } catch (e: any) {
-            console.error('Error deleting objet:', e);
-            return fail(500, { message: 'Erreur lors de la suppression' });
-        }
-    }
+		if (!id) {
+			return fail(400, { message: 'ID requis' });
+		}
+
+		try {
+			await db.delete(objets).where(eq(objets.id, id));
+			return { success: true };
+		} catch (e: any) {
+			console.error('Error deleting objet:', e);
+			return fail(500, { message: 'Erreur lors de la suppression' });
+		}
+	}
 };

--- a/src/routes/(app)/app/cerfa/pem/+page.server.ts
+++ b/src/routes/(app)/app/cerfa/pem/+page.server.ts
@@ -4,26 +4,37 @@ import { eq, isNotNull, not } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-    // Caractérisation PEM : Objets qui ne sont PAS des déchets (ou spécifiquement marqués comme PEM/Réemploi)
-    // Ici nous prenons par défaut tout ce qui est marqué comme réemploi
-    // Ou si vous préférez, tout ce qui n'est pas "deposeDechet" (à adapter selon logique métier)
-    // Pour l'instant, on se base sur deposeReemlpoi existant
-    const items = await db.select({
-        id: objets.id,
-        objet: objets.objet,
-        categorie: categorieV2.categoriev2,
-        groupe: groupe.groupe,
-        unite: objets.unite,
-        masseUnitaire: objets.masseUnitaire,
-        etat: objets.deposeReemlpoi // Utilise le champ de réemploi comme état pour l'instant
-    })
-    .from(objets)
-    .leftJoin(categorieV2, eq(objets.categorieId, categorieV2.id))
-    .leftJoin(groupe, eq(categorieV2.groupeId, groupe.id))
-    .where(isNotNull(objets.deposeReemlpoi)) // Filtrage simple: si une info réemploi existe
-    .all();
+	// Caractérisation PEM : Objets qui ne sont PAS des déchets (ou spécifiquement marqués comme PEM/Réemploi)
+	// Ici nous prenons par défaut tout ce qui est marqué comme réemploi
+	// Ou si vous préférez, tout ce qui n'est pas "deposeDechet" (à adapter selon logique métier)
+	// Pour l'instant, on se base sur deposeReemlpoi existant
+	const items = await db
+		.select({
+			id: objets.id,
+			objet: objets.objet,
+			categorie: categorieV2.categoriev2,
+			groupe: groupe.groupe,
+			unite: objets.unite,
+			masseUnitaire: objets.masseUnitaire,
+			etat: objets.deposeReemlpoi // Utilise le champ de réemploi comme état pour l'instant
+		})
+		.from(objets)
+		.leftJoin(categorieV2, eq(objets.categorieId, categorieV2.id))
+		.leftJoin(groupe, eq(categorieV2.groupeId, groupe.id))
+		.where(isNotNull(objets.deposeReemlpoi)) // Filtrage simple: si une info réemploi existe
+		.all();
 
-    return {
-        items
-    };
+	const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+	items.sort((a, b) => {
+		const g = collator.compare(a.groupe || '', b.groupe || '');
+		if (g !== 0) return g;
+		const c = collator.compare(a.categorie || '', b.categorie || '');
+		if (c !== 0) return c;
+		return collator.compare(a.objet || '', b.objet || '');
+	});
+
+	return {
+		items
+	};
 };

--- a/src/routes/(app)/app/projets/[id]/+page.server.ts
+++ b/src/routes/(app)/app/projets/[id]/+page.server.ts
@@ -2,190 +2,215 @@ import type { PageServerLoad, Actions } from './$types';
 import { error, fail } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { db } from '$lib/server/db/client';
-import { projet, etablissement, user, tagMail, tagsAmiante, tagsPlomb, tagsTermite, tagsStructure, pemd, groupe, categorieV2, objets } from '$lib/server/db/schema';
+import {
+	projet,
+	etablissement,
+	user,
+	tagMail,
+	tagsAmiante,
+	tagsPlomb,
+	tagsTermite,
+	tagsStructure,
+	pemd,
+	groupe,
+	categorieV2,
+	objets
+} from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
-    const { id } = params;
-    const currentUser = locals.user;
+	const { id } = params;
+	const currentUser = locals.user;
 
-    if (!currentUser) {
-        throw error(401, 'Non autorisé');
-    }
+	if (!currentUser) {
+		throw error(401, 'Non autorisé');
+	}
 
-    const result = await db.select().from(projet).where(eq(projet.id, id));
-    const project = result[0];
+	const result = await db.select().from(projet).where(eq(projet.id, id));
+	const project = result[0];
 
-    if (!project) {
-        throw error(404, 'Projet non trouvé');
-    }
+	if (!project) {
+		throw error(404, 'Projet non trouvé');
+	}
 
-    // Vérifier que l'utilisateur a accès à ce projet (admin ou même société)
-    if (currentUser.role !== 'admin') {
-        const userWithSociete = await db.select().from(user).where(eq(user.id, currentUser.id));
-        const societeId = userWithSociete[0]?.societeId;
+	// Vérifier que l'utilisateur a accès à ce projet (admin ou même société)
+	if (currentUser.role !== 'admin') {
+		const userWithSociete = await db.select().from(user).where(eq(user.id, currentUser.id));
+		const societeId = userWithSociete[0]?.societeId;
 
-        if (societeId) {
-            // Récupérer les établissements de la société
-            const etablissements = await db.select({ id: etablissement.id })
-                .from(etablissement)
-                .where(eq(etablissement.idSocieteId, societeId));
+		if (societeId) {
+			// Récupérer les établissements de la société
+			const etablissements = await db
+				.select({ id: etablissement.id })
+				.from(etablissement)
+				.where(eq(etablissement.idSocieteId, societeId));
 
-            const etablissementIds = etablissements.map(e => e.id);
+			const etablissementIds = etablissements.map((e) => e.id);
 
-            if (!etablissementIds.includes(project.idEtabId)) {
-                throw error(403, 'Accès non autorisé à ce projet');
-            }
-        }
-    }
+			if (!etablissementIds.includes(project.idEtabId)) {
+				throw error(403, 'Accès non autorisé à ce projet');
+			}
+		}
+	}
 
-    // Load tags for this project
-    const tags = await db.select().from(tagMail).where(eq(tagMail.projetIdId, id));
-    const amianteTags = await db.select().from(tagsAmiante).where(eq(tagsAmiante.sidId, id));
-    const plombTags = await db.select().from(tagsPlomb).where(eq(tagsPlomb.sidId, id));
-    const termiteTags = await db.select().from(tagsTermite).where(eq(tagsTermite.sidId, id));
-    const structureTags = await db.select().from(tagsStructure).where(eq(tagsStructure.sidId, id));
-    const pemdTags = await db.select().from(pemd).where(eq(pemd.sidId, id));
+	// Load tags for this project
+	const tags = await db.select().from(tagMail).where(eq(tagMail.projetIdId, id));
+	const amianteTags = await db.select().from(tagsAmiante).where(eq(tagsAmiante.sidId, id));
+	const plombTags = await db.select().from(tagsPlomb).where(eq(tagsPlomb.sidId, id));
+	const termiteTags = await db.select().from(tagsTermite).where(eq(tagsTermite.sidId, id));
+	const structureTags = await db.select().from(tagsStructure).where(eq(tagsStructure.sidId, id));
+	const pemdTags = await db.select().from(pemd).where(eq(pemd.sidId, id));
 
-    // Build facets for PEMD (groupe -> categorie -> objet) to drive UI filters/autocomplete
-    const pemdFacets = await db
-        .select({
-            groupeId: groupe.id,
-            groupeName: groupe.groupe,
-            categorieId: categorieV2.id,
-            categorieName: categorieV2.categoriev2,
-            objetId: objets.id,
-            objetName: objets.objet
-        })
-        .from(pemd)
-        .leftJoin(objets, eq(pemd.objetId, objets.id))
-        .leftJoin(categorieV2, eq(objets.categorieId, categorieV2.id))
-        .leftJoin(groupe, eq(categorieV2.groupeId, groupe.id))
-        .where(eq(pemd.sidId, id))
-        .orderBy(groupe.groupe, categorieV2.categoriev2, objets.objet);
+	// Natural sort helper
+	const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 
-    // Also load all groups and all categorie_v2 (master lists) to power the autocomplete.
-    const allGroups = await db
-        .select({ id: groupe.id, name: groupe.groupe })
-        .from(groupe)
-        .orderBy(groupe.groupe);
+	// Build facets for PEMD (groupe -> categorie -> objet) to drive UI filters/autocomplete
+	const pemdFacets = await db
+		.select({
+			groupeId: groupe.id,
+			groupeName: groupe.groupe,
+			categorieId: categorieV2.id,
+			categorieName: categorieV2.categoriev2,
+			objetId: objets.id,
+			objetName: objets.objet
+		})
+		.from(pemd)
+		.leftJoin(objets, eq(pemd.objetId, objets.id))
+		.leftJoin(categorieV2, eq(objets.categorieId, categorieV2.id))
+		.leftJoin(groupe, eq(categorieV2.groupeId, groupe.id))
+		.where(eq(pemd.sidId, id));
 
-    const categoriesV2 = await db
-        .select({ id: categorieV2.id, name: categorieV2.categoriev2, groupeId: categorieV2.groupeId })
-        .from(categorieV2)
-        .orderBy(categorieV2.categoriev2);
+	pemdFacets.sort((a, b) => {
+		const g = collator.compare(a.groupeName || '', b.groupeName || '');
+		if (g !== 0) return g;
+		const c = collator.compare(a.categorieName || '', b.categorieName || '');
+		if (c !== 0) return c;
+		return collator.compare(a.objetName || '', b.objetName || '');
+	});
 
-    const allPemdObjects = await db
-        .select({ id: objets.id, name: objets.objet, categorieId: objets.categorieId })
-        .from(objets)
-        .orderBy(objets.objet);
+	// Also load all groups and all categorie_v2 (master lists) to power the autocomplete.
+	const allGroups = await db.select({ id: groupe.id, name: groupe.groupe }).from(groupe);
 
-    return {
-        projet: project,
-        tags: tags,
-        amianteTags: amianteTags,
-        plombTags: plombTags,
-        termiteTags: termiteTags,
-        structureTags: structureTags,
-        pemdTags: pemdTags,
-        pemdFacets: pemdFacets,
-        groups: allGroups,
-        categoriesV2: categoriesV2,
-        allPemdObjects: allPemdObjects,
-        matterportSdkKey: env.MATTERPORT_SDK_KEY
-    };
+	allGroups.sort((a, b) => collator.compare(a.name || '', b.name || ''));
+
+	const categoriesV2 = await db
+		.select({ id: categorieV2.id, name: categorieV2.categoriev2, groupeId: categorieV2.groupeId })
+		.from(categorieV2);
+
+	categoriesV2.sort((a, b) => collator.compare(a.name || '', b.name || ''));
+
+	const allPemdObjects = await db
+		.select({ id: objets.id, name: objets.objet, categorieId: objets.categorieId })
+		.from(objets);
+
+	allPemdObjects.sort((a, b) => collator.compare(a.name || '', b.name || ''));
+
+	return {
+		projet: project,
+		tags: tags,
+		amianteTags: amianteTags,
+		plombTags: plombTags,
+		termiteTags: termiteTags,
+		structureTags: structureTags,
+		pemdTags: pemdTags,
+		pemdFacets: pemdFacets,
+		groups: allGroups,
+		categoriesV2: categoriesV2,
+		allPemdObjects: allPemdObjects,
+		matterportSdkKey: env.MATTERPORT_SDK_KEY
+	};
 };
 
 export const actions: Actions = {
-    createPemdTag: async ({ request, params, locals }) => {
-        const currentUser = locals.user;
-        if (!currentUser) {
-            return fail(401, { error: 'Non autorisé' });
-        }
+	createPemdTag: async ({ request, params, locals }) => {
+		const currentUser = locals.user;
+		if (!currentUser) {
+			return fail(401, { error: 'Non autorisé' });
+		}
 
-        const formData = await request.formData();
-        const projetId = params.id;
+		const formData = await request.formData();
+		const projetId = params.id;
 
-        // Extract form fields
-        const objetId = formData.get('objetId');
-        const natureId = formData.get('natureId');
-        const description = formData.get('description');
-        const quantite = formData.get('quantite');
-        const etage = formData.get('etage');
-        const etat = formData.get('etat');
-        const anchorPosition = formData.get('anchorPosition');
-        const stemVector = formData.get('stemVector');
-        const longueur = formData.get('longueur');
-        const largeur = formData.get('largeur');
-        const epaisseur = formData.get('epaisseur');
-        const potentielReemploi = formData.get('potentielReemploi');
+		// Extract form fields
+		const objetId = formData.get('objetId');
+		const natureId = formData.get('natureId');
+		const description = formData.get('description');
+		const quantite = formData.get('quantite');
+		const etage = formData.get('etage');
+		const etat = formData.get('etat');
+		const anchorPosition = formData.get('anchorPosition');
+		const stemVector = formData.get('stemVector');
+		const longueur = formData.get('longueur');
+		const largeur = formData.get('largeur');
+		const epaisseur = formData.get('epaisseur');
+		const potentielReemploi = formData.get('potentielReemploi');
 
-        if (!anchorPosition || !stemVector) {
-            return fail(400, { error: 'Position manquante' });
-        }
+		if (!anchorPosition || !stemVector) {
+			return fail(400, { error: 'Position manquante' });
+		}
 
-        try {
-            const newId = nanoid();
-            
-            await db.insert(pemd).values({
-                id: newId,
-                sidId: projetId,
-                objetId: objetId ? Number(objetId) : null,
-                natureId: natureId ? Number(natureId) : null,
-                description: description?.toString() || null,
-                quantite: quantite ? Number(quantite) : null,
-                etage: etage?.toString() || null,
-                etat: etat?.toString() || null,
-                anchorPosition: anchorPosition.toString(),
-                stemVector: stemVector.toString(),
-                longueur: longueur ? Number(longueur) : null,
-                largeur: largeur ? Number(largeur) : null,
-                epaisseur: epaisseur ? Number(epaisseur) : null,
-                potentielReemploi: potentielReemploi?.toString() || null,
-                color: '#9933FF', // Purple color for PEMD tags
-            });
+		try {
+			const newId = nanoid();
 
-            // Return the newly created tag data for immediate display
-            return { 
-                success: true, 
-                tag: {
-                    id: newId,
-                    sidId: projetId,
-                    objetId: objetId ? Number(objetId) : null,
-                    description: description?.toString() || null,
-                    quantite: quantite ? Number(quantite) : null,
-                    etage: etage?.toString() || null,
-                    etat: etat?.toString() || null,
-                    anchorPosition: anchorPosition.toString(),
-                    stemVector: stemVector.toString(),
-                }
-            };
-        } catch (e) {
-            console.error('Failed to create PEMD tag:', e);
-            return fail(500, { error: 'Échec de la création du tag' });
-        }
-    },
+			await db.insert(pemd).values({
+				id: newId,
+				sidId: projetId,
+				objetId: objetId ? Number(objetId) : null,
+				natureId: natureId ? Number(natureId) : null,
+				description: description?.toString() || null,
+				quantite: quantite ? Number(quantite) : null,
+				etage: etage?.toString() || null,
+				etat: etat?.toString() || null,
+				anchorPosition: anchorPosition.toString(),
+				stemVector: stemVector.toString(),
+				longueur: longueur ? Number(longueur) : null,
+				largeur: largeur ? Number(largeur) : null,
+				epaisseur: epaisseur ? Number(epaisseur) : null,
+				potentielReemploi: potentielReemploi?.toString() || null,
+				color: '#9933FF' // Purple color for PEMD tags
+			});
 
-    deletePemdTag: async ({ request, locals }) => {
-        const currentUser = locals.user;
-        if (!currentUser) {
-            return fail(401, { error: 'Non autorisé' });
-        }
+			// Return the newly created tag data for immediate display
+			return {
+				success: true,
+				tag: {
+					id: newId,
+					sidId: projetId,
+					objetId: objetId ? Number(objetId) : null,
+					description: description?.toString() || null,
+					quantite: quantite ? Number(quantite) : null,
+					etage: etage?.toString() || null,
+					etat: etat?.toString() || null,
+					anchorPosition: anchorPosition.toString(),
+					stemVector: stemVector.toString()
+				}
+			};
+		} catch (e) {
+			console.error('Failed to create PEMD tag:', e);
+			return fail(500, { error: 'Échec de la création du tag' });
+		}
+	},
 
-        const formData = await request.formData();
-        const tagId = formData.get('tagId');
+	deletePemdTag: async ({ request, locals }) => {
+		const currentUser = locals.user;
+		if (!currentUser) {
+			return fail(401, { error: 'Non autorisé' });
+		}
 
-        if (!tagId) {
-            return fail(400, { error: 'ID du tag manquant' });
-        }
+		const formData = await request.formData();
+		const tagId = formData.get('tagId');
 
-        try {
-            await db.delete(pemd).where(eq(pemd.id, tagId.toString()));
-            return { success: true, deletedId: tagId.toString() };
-        } catch (e) {
-            console.error('Failed to delete PEMD tag:', e);
-            return fail(500, { error: 'Échec de la suppression du tag' });
-        }
-    }
+		if (!tagId) {
+			return fail(400, { error: 'ID du tag manquant' });
+		}
+
+		try {
+			await db.delete(pemd).where(eq(pemd.id, tagId.toString()));
+			return { success: true, deletedId: tagId.toString() };
+		} catch (e) {
+			console.error('Failed to delete PEMD tag:', e);
+			return fail(500, { error: 'Échec de la suppression du tag' });
+		}
+	}
 };


### PR DESCRIPTION
This PR fixes issue #60 by implementing natural sorting for PEMD groups, categories, and objects.
Instead of simple alphabetical sorting, it now uses `Intl.Collator` with `numeric: true` to ensure that numbers within strings are handled correctly (e.g., "Category 2" comes before "Category 10").

Changes:
- Updated `src/routes/(app)/app/projets/[id]/+page.server.ts`
- Updated `src/routes/(app)/app/admin/categories/+page.server.ts`
- Updated `src/routes/(app)/app/admin/macro-categories/+page.server.ts`
- Updated `src/routes/(app)/app/admin/objets/+page.server.ts`
- Updated `src/routes/(app)/app/cerfa/pem/+page.server.ts`

Alternatives considered:
- Database schema change: Adding an `order` column would be the most robust but requires migrations.
- Client-side sorting: Possible, but keeping sorting on the server simplifies the UI components.